### PR TITLE
Extract the service retrieval to be able to mock it

### DIFF
--- a/src/Bitexpert/Magento/ListApiEndpoints/Command/ListApiEndpoints.php
+++ b/src/Bitexpert/Magento/ListApiEndpoints/Command/ListApiEndpoints.php
@@ -47,12 +47,10 @@ class ListApiEndpoints extends AbstractMagentoCommand
     {
         $this->detectMagento($output);
         if ($this->initMagento()) {
+            $services = $this->getDefinedServices();
             $outputFormat = $input->getOption(self::OPTION_OUTPUT_FORMAT);
-            /** @var \Magento\Webapi\Model\Config $serviceConfig */
-            $serviceConfig = ObjectManager::getInstance()->get(\Magento\Webapi\Model\Config::class);
-            $services = $serviceConfig->getServices();
-
-            switch ($outputFormat) {
+            switch ($outputFormat)
+            {
                 case 'table':
                     $this->printAsTable($services, $output);
                     break;
@@ -83,5 +81,15 @@ class ListApiEndpoints extends AbstractMagentoCommand
         }
 
         $table->render();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDefinedServices()
+    {
+        /** @var \Magento\Webapi\Model\Config $serviceConfig */
+        $serviceConfig = ObjectManager::getInstance()->get(\Magento\Webapi\Model\Config::class);
+        return $serviceConfig->getServices();
     }
 }


### PR DESCRIPTION
To make the command testable, the logic to retrieve the services is extracted into a separate method.